### PR TITLE
Take unquoted commands and make `watch` the default mode

### DIFF
--- a/src/Config.hs
+++ b/src/Config.hs
@@ -19,7 +19,7 @@ instance FromJSON Config where
 
 data TriggerItem = TriggerItem
   { dirs      :: ![FilePath]
-  , cmd       :: !FilePath
+  , cmd       :: !String
   , recursive :: !Bool
   } deriving Show
 

--- a/src/Flags.hs
+++ b/src/Flags.hs
@@ -5,7 +5,7 @@ module Flags (SBMode(..), getCmdLine) where
 import           System.Console.CmdArgs
 
 data SBMode = Watch { dir       :: FilePath
-                    , cmd       :: [FilePath]
+                    , cmd       :: [String]
                     , recursive :: Bool
                     }
             | Triggers { config :: Maybe FilePath }

--- a/src/Flags.hs
+++ b/src/Flags.hs
@@ -8,7 +8,7 @@ data SBMode = Watch { dir       :: FilePath
                     , cmd       :: Maybe FilePath
                     , recursive :: Bool
                     }
-            | Triggers { config    :: Maybe FilePath }
+            | Triggers { config :: Maybe FilePath }
             deriving (Show, Data, Typeable)
 
 watch :: SBMode

--- a/src/Flags.hs
+++ b/src/Flags.hs
@@ -24,7 +24,7 @@ triggers = Triggers{ config = def
                    } &= help "Specify triggers from a config file"
 
 cmdLineMode :: Mode (CmdArgs SBMode)
-cmdLineMode = cmdArgsMode $ modes [triggers &= auto, watch]
+cmdLineMode = cmdArgsMode $ modes [triggers, watch &= auto]
                &= help "Watch directories and trigger tasks on changes"
                &= program "stickybeak"
                &= summary "stickybeak v0.1.0"

--- a/src/Flags.hs
+++ b/src/Flags.hs
@@ -5,7 +5,7 @@ module Flags (SBMode(..), getCmdLine) where
 import           System.Console.CmdArgs
 
 data SBMode = Watch { dir       :: FilePath
-                    , cmd       :: Maybe FilePath
+                    , cmd       :: [FilePath]
                     , recursive :: Bool
                     }
             | Triggers { config :: Maybe FilePath }
@@ -13,8 +13,8 @@ data SBMode = Watch { dir       :: FilePath
 
 watch :: SBMode
 watch = Watch{ dir = "." &= help "Directory to watch" &= typ "DIR"
-             , cmd = def &= help "Command to run on file changes" &= typ "CMD"
-             , recursive = def &= help "Watch subdirectories, as well."
+             , cmd = def &= args &= typ "COMMAND"
+             , recursive = def &= help "Watch subdirectories as well."
              } &= help "Watch dir and run cmd on file changes"
 
 triggers :: SBMode
@@ -28,6 +28,8 @@ cmdLineMode = cmdArgsMode $ modes [triggers, watch &= auto]
                &= help "Watch directories and trigger tasks on changes"
                &= program "stickybeak"
                &= summary "stickybeak v0.1.0"
+               &= helpArg [explicit, name "h"]
+               &= noAtExpand
 
 getCmdLine :: IO SBMode
 getCmdLine = cmdArgsRun cmdLineMode

--- a/src/StickyBeak.hs
+++ b/src/StickyBeak.hs
@@ -16,10 +16,7 @@ stickybeak :: IO ()
 stickybeak = do
   mode <- getCmdLine
   case mode of
-    Watch{..}    -> do
-      cmd' <- checkForCmd (Just cmd)
-      print cmd'
-      watchMode dir cmd' recursive
+    Watch{..}    -> watchMode dir (unwords cmd) recursive
     Triggers{..} -> triggerMode (fromMaybe defaultConfig config)
 
 waitToQuit :: IO ()
@@ -27,17 +24,18 @@ waitToQuit = do
     putStrLn "hit enter to quit"
     void getLine
 
-checkForCmd :: Maybe [FilePath] -> IO FilePath
-checkForCmd cmd = do
+checkForCmd :: String -> IO String
+checkForCmd cmd =
   case cmd of
-    Nothing   -> exitFailureMsg "Error: Did not provide a command to run"
-    Just cmd' -> return $ unwords cmd'
+    ""   -> exitFailureMsg "Error: Did not provide a command to run"
+    cmd' -> return cmd'
 
-watchMode :: FilePath -> FilePath -> Bool -> IO ()
+watchMode :: FilePath -> String -> Bool -> IO ()
 watchMode dir cmd rec = do
+    cmd' <- checkForCmd cmd
     wds <- if rec
-            then watchWithRec cmd dir
-            else (:[]) <$> watchWith cmd dir
+            then watchWithRec cmd' dir
+            else (:[]) <$> watchWith cmd' dir
     waitToQuit
     removeWatches wds
   where removeWatches = mapM_ removeWatch


### PR DESCRIPTION
This makes `watch` the default mode and makes it so that arguments do not need to be quoted, e.g.

`stickybeak -d src echo hello world`

instead of

`stickybeak -d src -c "echo hello world"`.

This change removes the `-c` flag needed and assumes that all extraneous arguments are the command to run. 