### PR TITLE
Only make one INotify instance per process

### DIFF
--- a/src/StickyBeak.hs
+++ b/src/StickyBeak.hs
@@ -10,14 +10,16 @@ import           Error            (exitFailureMsg)
 import           Flags
 import           System.Directory (doesFileExist)
 import           System.INotify   (removeWatch)
+import           System.INotify
 import           WatchUtils       (watchFromTrigger, watchWith, watchWithRec)
 
 stickybeak :: IO ()
 stickybeak = do
+  inotify <- initINotify
   mode <- getCmdLine
   case mode of
-    Watch{..}    -> watchMode dir (unwords cmd) recursive
-    Triggers{..} -> triggerMode (fromMaybe defaultConfig config)
+    Watch{..}    -> watchMode inotify dir (unwords cmd) recursive
+    Triggers{..} -> triggerMode inotify (fromMaybe defaultConfig config)
 
 waitToQuit :: IO ()
 waitToQuit = do
@@ -30,24 +32,24 @@ checkForCmd cmd =
     ""   -> exitFailureMsg "Error: Did not provide a command to run"
     cmd' -> return cmd'
 
-watchMode :: FilePath -> String -> Bool -> IO ()
-watchMode dir cmd rec = do
+watchMode :: INotify -> FilePath -> String -> Bool -> IO ()
+watchMode inotify dir cmd rec = do
     cmd' <- checkForCmd cmd
     wds <- if rec
-            then watchWithRec cmd' dir
-            else (:[]) <$> watchWith cmd' dir
+              then watchWithRec inotify cmd' dir
+              else (:[]) <$> watchWith inotify cmd' dir
     waitToQuit
     removeWatches wds
   where removeWatches = mapM_ removeWatch
 
-triggerMode :: FilePath -> IO ()
-triggerMode path = do
+triggerMode :: INotify -> FilePath -> IO ()
+triggerMode inotify path = do
     fileExists <- doesFileExist path
     unless fileExists (exitFailureMsg $ "Error: Could not find " ++ path)
     conf <- parseConfig path
     when (isNothing conf) (exitFailureMsg $ "Error: Could not parse " ++ path)
     let Config{..} = fromMaybe Config{triggers = []} conf
-    wds <- concat <$> mapM watchFromTrigger triggers
+    wds <- concat <$> mapM (watchFromTrigger inotify) triggers
     waitToQuit
     removeWatches wds
   where removeWatches = mapM_ removeWatch


### PR DESCRIPTION
This attempts to resolve #13. Before this change we would generate a new
INotify instance for every subscription. This creates a single instance
and passes it along to all watch methods.