### PR TITLE
Change event notification type from `Modify` to `CloseWrite`

### DIFF
--- a/src/WatchUtils.hs
+++ b/src/WatchUtils.hs
@@ -14,8 +14,7 @@ import           System.Directory                      (doesDirectoryExist,
                                                         listDirectory)
 import           System.FilePath                       ((</>))
 import           System.INotify
-import           System.Process                        (CreateProcess (..),
-                                                        createProcess, shell)
+import           System.Process                        (createProcess, shell)
 
 -- | Maximum size for bounded event channels.
 maxChanSize :: Int
@@ -42,7 +41,7 @@ withEventChan chan cmd = void . forkIO . forever $ readChan chan >> cmd
 -- returns the WatchDescriptor for later removal.
 watchWith :: INotify -> FilePath -> FilePath -> IO WatchDescriptor
 watchWith inotify cmd dir = do
-  (eventChan, wd) <- subscribe inotify [Modify] dir
+  (eventChan, wd) <- subscribe inotify [CloseWrite] dir
   withEventChan eventChan $ runCmd cmd
   return wd
 


### PR DESCRIPTION
`Modify` catches too many unnecessary modifications to files which may
trigger commands to run multiple times after a single file was written
to. This changes the default watch from `Modify` to `CloseWrite` which
should more accurately create a 1:1 correspondence between writes and
commands run.

See #8 for a similar discussion.