### PR TITLE
Make jobs wait for debounce time

### DIFF
--- a/src/Stickybeak.hs
+++ b/src/Stickybeak.hs
@@ -1,42 +1,33 @@
-{-# LANGUAGE DeriveFunctor             #-}
-{-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE FlexibleContexts          #-}
-{-# LANGUAGE GADTs                     #-}
-{-# LANGUAGE RecordWildCards           #-}
+{-# LANGUAGE RecordWildCards #-}
 
 module Stickybeak
   ( stickybeak
   ) where
 
-import           Control.Concurrent                    (ThreadId, forkIO)
-import           Control.Concurrent.Chan.Unagi.Bounded (InChan, OutChan,
-                                                        newChan, readChan,
-                                                        tryWriteChan)
-import           Control.Monad                         (forever, void)
-import           Data.Semigroup                        ((<>))
-import           Options.Applicative                   (Parser, ParserInfo (..),
-                                                        argument, execParser,
-                                                        fullDesc, header, help,
-                                                        helper, info, long,
-                                                        metavar, progDesc,
-                                                        short, str, switch,
-                                                        (<**>))
-import           System.Exit                           (exitSuccess)
-import           System.INotify                        (Event,
-                                                        EventVariety (..),
-                                                        INotify,
-                                                        WatchDescriptor,
-                                                        addWatch, initINotify,
-                                                        removeWatch)
-import           System.Process                        (readCreateProcess,
-                                                        shell)
+import           Control.Concurrent           (ThreadId, forkIO)
+import           Control.Concurrent.Async
+import           Control.Concurrent.STM
+import           Control.Concurrent.STM.TMVar
+import           Control.Monad                (forever, void)
+import           Data.Map                     (Map)
+import qualified Data.Map                     as Map
+import           Data.Semigroup               ((<>))
+import           Data.Time                    (UTCTime (..), getCurrentTime)
+import           Options.Applicative          (Parser, ParserInfo (..),
+                                               argument, execParser, fullDesc,
+                                               header, help, helper, info, long,
+                                               metavar, progDesc, short, str,
+                                               switch, (<**>))
+import           System.Exit                  (exitSuccess)
+import           System.INotify               (Event, EventVariety (..),
+                                               INotify, WatchDescriptor,
+                                               addWatch, initINotify,
+                                               removeWatch)
+import           System.Process               (ProcessHandle, readCreateProcess,
+                                               shell)
 
-data Job = Job
-    { inChan  :: InChan Event
-    , outChan :: OutChan Event
-    , inotify :: INotify
-    -- Might need some kind of collection to keep track of WatchDescriptors.
-    }
+data Job = Job ProcessHandle UTCTime
+type JobMap = Map String Job
 
 data Args = Args
   { target    :: String
@@ -45,47 +36,43 @@ data Args = Args
   } deriving (Show)
 
 progArgs :: Parser Args
-progArgs = Args
-  <$> argument str
-      ( metavar "TARGET"
-     <> help "Target to watch" )
-  <*> argument str
-      ( metavar "COMMAND"
-     <> help "Command to run on file changes" )
-  <*> switch
-      ( long "recursive"
-     <> short 'r'
-     <> help "Watch subdirectories recursively" )
+progArgs =
+  Args <$> argument str (metavar "TARGET" <> help "Target to watch") <*>
+  argument str (metavar "COMMAND" <> help "Command to run on file changes") <*>
+  switch
+    (long "recursive" <> short 'r' <> help "Watch subdirectories recursively")
 
 progInfo :: ParserInfo Args
-progInfo = info (progArgs <**> helper)
-              ( fullDesc
-             <> progDesc "Watch TARGET and run COMMAND on changes"
-             <> header "stickybeak" )
+progInfo =
+  info
+    (progArgs <**> helper)
+    (fullDesc <> progDesc "Watch TARGET and run COMMAND on changes" <>
+     header "stickybeak")
 
-subscribe :: Job -> Args -> IO Job
-subscribe Job{..} Args{..} = do
-  wd <- addWatch inotify [CloseWrite] target (\evt -> void (tryWriteChan inChan evt))
-  return $ Job inChan outChan inotify
+{- subscribe :: Job -> Args -> IO Job -}
+{- subscribe Job {..} Args {..} = do -}
+  {- wd <- addWatch inotify [CloseWrite] target eventHandler -}
+  {- return $ Job inChan outChan inotify -}
+  {- where -}
+    {- eventHandler evt = void (tryWriteChan inChan evt) -}
 
-newJob :: IO Job
-newJob = do
-  (ic, oc) <- newChan 1
-  inotify <- initINotify
-  return $ Job ic oc inotify
+{- newJob :: IO Job -}
+{- newJob = do -}
+  {- (ic, oc) <- newChan 1 -}
+  {- inotify <- initINotify -}
+  {- return $ Job ic oc inotify -}
 
--- TODO change this from forkIO to async, that way we can `cancel`
--- instead of using `getLine`
-newWorker :: Job -> Args -> IO ThreadId
-newWorker Job{..} Args{..} = forkIO $ forever cmd
-  where cmd = readChan outChan >> readCreateProcess (shell command) "" >>= putStr
-  {- where cmd = readChan outChan >>= print -}
+{- -- TODO change this from forkIO to async, that way we can `cancel` -}
+{- -- instead of using `getLine` -}
+{- newWorker :: Job -> Args -> IO ThreadId -}
+{- newWorker Job {..} Args {..} = forkIO $ forever cmd -}
+  {- {- where cmd = readChan outChan >> readCreateProcess (shell command) "" >>= putStr -} -}
+  {- where -}
+    {- cmd = readChan outChan >>= print -}
+
+
 
 stickybeak :: IO ()
 stickybeak = do
   args <- execParser progInfo
-  job <- newJob
-  worker <- newWorker job args
-  subscribe job args
-  _ <- getLine
   exitSuccess

--- a/src/Stickybeak.hs
+++ b/src/Stickybeak.hs
@@ -1,32 +1,29 @@
-{-# LANGUAGE RecordWildCards #-}
-
 module Stickybeak
   ( stickybeak
   ) where
 
-import           Control.Concurrent           (ThreadId, forkIO)
-import           Control.Concurrent.Async
+{- import           Control.Concurrent.Async -}
 import           Control.Concurrent.STM
-import           Control.Concurrent.STM.TMVar
-import           Control.Monad                (forever, void)
-import           Data.Map                     (Map)
-import qualified Data.Map                     as Map
-import           Data.Semigroup               ((<>))
-import           Data.Time                    (UTCTime (..), getCurrentTime)
-import           Options.Applicative          (Parser, ParserInfo (..),
-                                               argument, execParser, fullDesc,
-                                               header, help, helper, info, long,
-                                               metavar, progDesc, short, str,
-                                               switch, (<**>))
-import           System.Exit                  (exitSuccess)
-import           System.INotify               (Event, EventVariety (..),
-                                               INotify, WatchDescriptor,
-                                               addWatch, initINotify,
-                                               removeWatch)
-import           System.Process               (ProcessHandle, readCreateProcess,
-                                               shell)
+import           Data.Map.Strict        (Map)
+import qualified Data.Map.Strict        as Map
+import           Data.Semigroup         ((<>))
+import           Data.Time              (UTCTime (..), diffUTCTime,
+                                         getCurrentTime)
+import           Options.Applicative    (Parser, ParserInfo (..), argument,
+                                         execParser, fullDesc, header, help,
+                                         helper, info, long, metavar, progDesc,
+                                         short, str, switch, (<**>))
+import           System.Exit            (exitSuccess)
+import           System.INotify         (EventVariety (..), INotify,
+                                         WatchDescriptor, addWatch, initINotify,
+                                         removeWatch)
+import           System.Process         (ProcessHandle, spawnCommand)
 
 data Job = Job ProcessHandle UTCTime
+
+instance Show Job where
+  show (Job _ ts) = show ts
+
 type JobMap = Map String Job
 
 data Args = Args
@@ -36,43 +33,51 @@ data Args = Args
   } deriving (Show)
 
 progArgs :: Parser Args
-progArgs =
-  Args <$> argument str (metavar "TARGET" <> help "Target to watch") <*>
-  argument str (metavar "COMMAND" <> help "Command to run on file changes") <*>
-  switch
-    (long "recursive" <> short 'r' <> help "Watch subdirectories recursively")
+progArgs = Args
+  <$> argument str
+      ( metavar "TARGET"
+     <> help "Target to watch" )
+  <*> argument str
+      ( metavar "COMMAND"
+     <> help "Command to run on file changes" )
+  <*> switch
+      ( long "recursive"
+     <> short 'r'
+     <> help "Watch subdirectories recursively" )
 
 progInfo :: ParserInfo Args
-progInfo =
-  info
-    (progArgs <**> helper)
-    (fullDesc <> progDesc "Watch TARGET and run COMMAND on changes" <>
-     header "stickybeak")
+progInfo = info (progArgs <**> helper)
+              ( fullDesc
+             <> progDesc "Watch TARGET and run COMMAND on changes"
+             <> header "stickybeak" )
 
-{- subscribe :: Job -> Args -> IO Job -}
-{- subscribe Job {..} Args {..} = do -}
-  {- wd <- addWatch inotify [CloseWrite] target eventHandler -}
-  {- return $ Job inChan outChan inotify -}
-  {- where -}
-    {- eventHandler evt = void (tryWriteChan inChan evt) -}
+defaultDebounce :: RealFrac a => a
+defaultDebounce = 0.250
 
-{- newJob :: IO Job -}
-{- newJob = do -}
-  {- (ic, oc) <- newChan 1 -}
-  {- inotify <- initINotify -}
-  {- return $ Job ic oc inotify -}
-
-{- -- TODO change this from forkIO to async, that way we can `cancel` -}
-{- -- instead of using `getLine` -}
-{- newWorker :: Job -> Args -> IO ThreadId -}
-{- newWorker Job {..} Args {..} = forkIO $ forever cmd -}
-  {- {- where cmd = readChan outChan >> readCreateProcess (shell command) "" >>= putStr -} -}
-  {- where -}
-    {- cmd = readChan outChan >>= print -}
-
-
+subscribe :: INotify -> TMVar JobMap -> Args -> IO WatchDescriptor
+subscribe inotify jobMap args = addWatch inotify [CloseWrite] (target args) eventHandler
+  where
+    eventHandler _ = do
+      ts <- getCurrentTime
+      (jm, needsUpdate) <- atomically $ do
+        jm' <- takeTMVar jobMap
+        case Map.lookup (command args) jm' of
+          Nothing -> return (jm', True)
+          Just (Job _ ts') -> if diffUTCTime ts ts' > defaultDebounce
+                                 then return (jm', True)
+                                 else return (jm', False)
+      if needsUpdate
+         then do
+           ph <- spawnCommand (command args)
+           atomically $ putTMVar jobMap $ Map.insert (command args) (Job ph ts) jm
+          else atomically $ putTMVar jobMap jm
 
 stickybeak :: IO ()
 stickybeak = do
   args <- execParser progInfo
+  jobMap <- atomically $ newTMVar Map.empty
+  inotify <- initINotify
+  wd <- subscribe inotify jobMap args
+  _ <- getLine
+  removeWatch wd
   exitSuccess

--- a/stickybeak.cabal
+++ b/stickybeak.cabal
@@ -16,14 +16,16 @@ library
   hs-source-dirs:     src
   exposed-modules:    Stickybeak
   build-depends:      base >= 4.7 && < 5
-                    , text
-                    , unix
-                    , process
-                    , unagi-chan
+                    , async
+                    , containers
+                    , directory
                     , hinotify
                     , optparse-applicative
-                    , directory
-                    , containers
+                    , process
+                    , stm
+                    , text
+                    , time
+                    , unix
   default-language:    Haskell2010
   ghc-options:         -Wall -fwarn-tabs
 


### PR DESCRIPTION
This still has work to go, namely:

* We are spawning new processes, but we do nothing with the old process (which may be running longer than the debounce time), so we'll need to terminate ProcessHandles prior to spawning new ones.
* We need a workaround for the h/inotify issue regarding watching individual files (namely watching them seems to only fire one event only and then stop)
* We need to flesh out the `--recursive` option for watching all sub-directories of the given directory