### PR TITLE
Build with mafia in addition to stack

### DIFF
--- a/stickybeak.cabal
+++ b/stickybeak.cabal
@@ -15,17 +15,18 @@ cabal-version:       >=1.10
 library
   hs-source-dirs:     src
   exposed-modules:    Stickybeak
-  build-depends:      base >= 4.7 && < 5
-                    , async
-                    , containers
-                    , directory
-                    , hinotify
-                    , optparse-applicative
+  build-depends:      base == 4.9.1.0
+                    , async == 2.1.1
+                    , containers == 0.5.7.1
+                    , directory == 1.3.0.0
+                    , hinotify == 0.3.9
+                    , optparse-applicative == 0.13.2.0
                     , process
-                    , stm
-                    , text
-                    , time
-                    , unix
+                    , stm == 2.4.4.1
+                    , text == 1.2.2.1
+                    , time == 1.6.0.1
+                    , unix == 2.7.2.1
+                    , bytestring == 0.10.8.1
   default-language:    Haskell2010
   ghc-options:         -Wall -fwarn-tabs
 

--- a/stickybeak.lock-8.0.2
+++ b/stickybeak.lock-8.0.2
@@ -1,0 +1,14 @@
+# mafia-lock-file-version: 0
+ansi-terminal == 0.8.0.4
+ansi-wl-pprint == 0.6.8.2
+async == 2.1.1
+colour == 2.3.4
+hinotify == 0.3.9
+optparse-applicative == 0.13.2.0
+primitive == 0.6.3.0
+QuickCheck == 2.11.3
+random == 1.1
+stm == 2.4.4.1
+text == 1.2.2.1
+tf-random == 0.5
+transformers-compat == 0.5.1.4

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,6 +1,6 @@
 module Main where
 
-import           Stickybeak
+--import           Stickybeak
 import           Test.QuickCheck
 
 prop_sanity :: Int -> Int -> Bool


### PR DESCRIPTION
Running `mafia build` blew up with type checking errors at `addWatch` complaining it took a `RawFilePath` instead of a `String`. I'll need to look in to why this fix is needed, it's possible it's pulling down a different version of inotify that's using the `ByteString` for the file path, but that makes sense since POSIX systems tend to always return bytestrings despite what they claim. 